### PR TITLE
chore(security): pin actions to specific commits

### DIFF
--- a/.github/workflows/monitor-famous-actions.yml
+++ b/.github/workflows/monitor-famous-actions.yml
@@ -17,10 +17,10 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 on 2025-06-26, TODO: consider using a release
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4 on 2025-06-26, TODO: consider using a release
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Third-party Github Actions should be referenced by commmit hash instead of tags or versions.

Git tags and branches are not immutable (commit hashes are), and the code for an action 'pinned' to a tag or branch may change:

- Git tags can be deleted and pointed to a different commit hence insecure.
- Git branches always reference the latest commit in that branch hence non deterministic.

This means that if the repo containing the third party action is compromised in some way, malicious code will enter the build pipeline.
